### PR TITLE
metrolopy new release v0.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "metrolopy" %}
-{% set version = "0.5.7" %}
+{% set version = "0.6.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 63afaab360ef9086705fc0dbda601aaeb0b9298e347906bd099218782d8ecdf2
+  sha256: d970b7403892bb01899def3bcd5303882e0acdf59a4bd3c42af69045d3feccf2
 
 build:
   number: 0
@@ -20,8 +20,8 @@ requirements:
     - pip
     - python >=3.5
   run:
-    - numpy
-    - matplotlib
+    - numpy >=1.13
+    - matplotlib-base
     - pandas
     - python >=3.5
     - scipy


### PR DESCRIPTION
updated v0.5.7 to v0.6.0
edited requirements:
added >=1.13 to numpy
replaced matplotlib with matplotlib-base

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
